### PR TITLE
Use associated constant instead of method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ keywords = ["tuple", "tuples", "arity", "generic", "trait"]
 repository = "https://github.com/TheBerkin/tuple-arity"
 readme = "README.md"
 license = "MIT"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Nicholas Fleck <TheBerkin@users.noreply.github.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ You can also use the `Arity` trait to get the arity of a tuple type directly:
 ```rust
 use tuple_arity::Arity;
 
-assert_eq!(0, <()>::arity());
-assert_eq!(1, <(u8,)>::arity());
-assert_eq!(2, <(u8, u8)>::arity());
-assert_eq!(3, <(u8, u8, u8)>::arity());
-assert_eq!(4, <(u8, u8, u8, u8)>::arity());
+assert_eq!(0, <()>::ARITY);
+assert_eq!(1, <(u8,)>::ARITY);
+assert_eq!(2, <(u8, u8)>::ARITY);
+assert_eq!(3, <(u8, u8, u8)>::ARITY);
+assert_eq!(4, <(u8, u8, u8, u8)>::ARITY);
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,22 +6,41 @@ pub trait Arity {
     /// ```rust
     /// use tuple_arity::Arity;
     /// 
+    /// assert_eq!(0, <()>::ARITY);
+    /// assert_eq!(1, <(u8,)>::ARITY);
+    /// assert_eq!(2, <(u8, u8)>::ARITY);
+    /// assert_eq!(3, <(u8, u8, u8)>::ARITY);
+    /// assert_eq!(4, <(u8, u8, u8, u8)>::ARITY);
+    /// ```
+    const ARITY: usize;
+
+
+    /// Gets the arity of the type.
+    ///
+    /// Example
+    /// ```rust
+    /// use tuple_arity::Arity;
+    /// 
     /// assert_eq!(0, <()>::arity());
     /// assert_eq!(1, <(u8,)>::arity());
     /// assert_eq!(2, <(u8, u8)>::arity());
     /// assert_eq!(3, <(u8, u8, u8)>::arity());
     /// assert_eq!(4, <(u8, u8, u8, u8)>::arity());
     /// ```
-    fn arity() -> usize;
+    #[deprecated(
+        since = "0.1.3",
+        note = "Use the associated constant `ARITY` instead",
+    )]
+    #[inline(always)]
+    fn arity() -> usize {
+        Self::ARITY
+    }
 }
 
 macro_rules! impl_tuple_arity {
     ($len:expr, $($tuple_arg:ident),*) => {
         impl<$($tuple_arg,)*> Arity for ($($tuple_arg,)*) {
-            #[inline(always)]
-            fn arity() -> usize {
-                $len
-            }
+            const ARITY: usize = $len;
         }
     }
 }
@@ -38,7 +57,7 @@ macro_rules! impl_tuple_arity {
 /// ```
 #[inline(always)]
 pub fn tuple_arity<T: Arity>(_: &T) -> usize {
-    T::arity()
+    T::ARITY
 }
 
 


### PR DESCRIPTION
This enables the arity expression to be referenced in constant expressions